### PR TITLE
change tap ios button on focus

### DIFF
--- a/src/components/UI/Button/index.tsx
+++ b/src/components/UI/Button/index.tsx
@@ -55,12 +55,12 @@ interface StyledButtonProps {
 
 const StyledButton = styled.button<StyledButtonProps>`
   all: unset;
+  -webkit-tap-highlight-color: transparent;
   border-radius: 100px;
   padding: 12px 20px;
   cursor: pointer;
   font-weight: 400;
   display: flex;
-  
   justify-content: space-between;
   align-items: center;
 


### PR DESCRIPTION
this seems to be an accesibility functionality of ios,

i'm trying this workaround
https://stackoverflow.com/questions/11885161/remove-grey-background-on-link-clicked-in-ios-safari-chrome-firefox

